### PR TITLE
Update SqlTokenizer.java

### DIFF
--- a/src/main/java/com/snowflake/dlsync/parser/SqlTokenizer.java
+++ b/src/main/java/com/snowflake/dlsync/parser/SqlTokenizer.java
@@ -251,6 +251,7 @@ public class SqlTokenizer {
 
             String fullObjectName = matcher.group("name");
             String scriptObjectName  = fullObjectName.split("\\.")[2];
+            scriptObjectName = scriptObjectName.replaceAll("^\"|\"$", "");
 
             if (objectType.isMigration()) {
                 MigrationScript script = ScriptFactory.getMigrationScript(database, schema, objectType, scriptObjectName, content);


### PR DESCRIPTION
Adding extra condition for quoted tables like :  
DATABASE.TABLE."tablename" 
— quoted so " should be removed in order to correct processing the filename (when using the createscript option)

(for windows hosted system)