### PR TITLE
Fix: Use fully qualified table names for DLSync metadata tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # DLSync Changelog
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.0.1] - 2026-02-05
+### Fixed
+- Fixed session context issue when managing account-level objects (databases, schemas). DLSync metadata tables now use fully qualified names to prevent "table does not exist" errors after Snowflake automatically switches session context.
 ## [3.0.0] - 2026-01-15
 ### Added
 - Added support for account level objects like database, schemas, roles, warehouses etc.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-releaseVersion=3.0.0
+releaseVersion=3.0.1

--- a/src/main/java/com/snowflake/dlsync/doa/ScriptRepo.java
+++ b/src/main/java/com/snowflake/dlsync/doa/ScriptRepo.java
@@ -42,17 +42,17 @@ public class ScriptRepo {
         log.info("Using database [{}] and schema [{}] for dlsync activities.", resultSet.getString(1), resultSet.getString(2));
         log.debug("Checking for deployment tables");
         try {
-            String query = "SELECT * FROM " + getFullyQualifiedChangeSyncTable() + " LIMIT 1;";
+            String query = "SELECT * FROM " + getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME) + " LIMIT 1;";
             Statement statement = connection.createStatement();
             statement.executeQuery(query);
             updateOldTableNames();
         } catch (SQLException e) {
             log.info("Running for the first time. Creating required tables.");
-            String createChangeSyncSql = "CREATE OR REPLACE TABLE " + getFullyQualifiedChangeSyncTable() + " (ID integer PRIMARY KEY, CHANGE_TYPE varchar, STATUS varchar, LOG varchar, CHANGE_COUNT integer, START_TIME timestamp, END_TIME timestamp);";
+            String createChangeSyncSql = "CREATE OR REPLACE TABLE " + getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME) + " (ID integer PRIMARY KEY, CHANGE_TYPE varchar, STATUS varchar, LOG varchar, CHANGE_COUNT integer, START_TIME timestamp, END_TIME timestamp);";
 
-            String createSqlHash = "CREATE OR REPLACE TABLE " + getFullyQualifiedScriptHistoryTable() + " (SCRIPT_ID VARCHAR, OBJECT_NAME varchar, OBJECT_TYPE varchar, ROLLBACK_SCRIPT varchar, SCRIPT_HASH varchar, DEPLOYED_HASH varchar, CHANGE_SYNC_ID integer, CREATED_BY varchar, CREATED_TS timestamp, UPDATED_BY varchar, UPDATED_TS timestamp, FOREIGN KEY (CHANGE_SYNC_ID) REFERENCES " + getFullyQualifiedChangeSyncTable() + "(ID));";
+            String createSqlHash = "CREATE OR REPLACE TABLE " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + " (SCRIPT_ID VARCHAR, OBJECT_NAME varchar, OBJECT_TYPE varchar, ROLLBACK_SCRIPT varchar, SCRIPT_HASH varchar, DEPLOYED_HASH varchar, CHANGE_SYNC_ID integer, CREATED_BY varchar, CREATED_TS timestamp, UPDATED_BY varchar, UPDATED_TS timestamp, FOREIGN KEY (CHANGE_SYNC_ID) REFERENCES " + getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME) + "(ID));";
 
-            String createSqlEvent = "CREATE OR REPLACE TABLE " + getFullyQualifiedScriptEventTable() + " (ID VARCHAR, SCRIPT_ID VARCHAR, OBJECT_NAME varchar, SCRIPT_HASH varchar, STATUS varchar, LOG varchar, CHANGE_SYNC_ID integer, CREATED_BY varchar, CREATED_TS timestamp, FOREIGN KEY (CHANGE_SYNC_ID) REFERENCES " + getFullyQualifiedChangeSyncTable() + "(ID));";
+            String createSqlEvent = "CREATE OR REPLACE TABLE " + getFullyQualifiedTableName(SCRIPT_EVENT_TABLE_NAME) + " (ID VARCHAR, SCRIPT_ID VARCHAR, OBJECT_NAME varchar, SCRIPT_HASH varchar, STATUS varchar, LOG varchar, CHANGE_SYNC_ID integer, CREATED_BY varchar, CREATED_TS timestamp, FOREIGN KEY (CHANGE_SYNC_ID) REFERENCES " + getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME) + "(ID));";
             log.debug("create hash table sql: {}", createSqlHash);
             log.debug("create event table sql: {}", createSqlEvent);
             Statement statement = connection.createStatement();
@@ -69,7 +69,7 @@ public class ScriptRepo {
             Statement statement = connection.createStatement();
             statement.executeQuery(query);
             log.info("Found old dlsync table DL_SYNC_SCRIPT renaming it to [{}]", SCRIPT_HISTORY_TABLE_NAME);
-            String alterSql = "ALTER TABLE IF EXISTS " + oldTableName + " RENAME TO " + getFullyQualifiedScriptHistoryTable() + ";";
+            String alterSql = "ALTER TABLE IF EXISTS " + oldTableName + " RENAME TO " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + ";";
             statement.executeUpdate(alterSql);
         } catch (SQLException e) {
             log.debug("All tables are with new version");
@@ -77,7 +77,7 @@ public class ScriptRepo {
     }
 
     public Set<String> loadScriptHash() throws SQLException {
-        String hashQuery =  "SELECT * FROM " + getFullyQualifiedScriptHistoryTable() + ";";
+        String hashQuery =  "SELECT * FROM " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + ";";
         log.debug("Loading hash with sql: {}", hashQuery);
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(hashQuery);
@@ -92,7 +92,7 @@ public class ScriptRepo {
 
     public Set<String> loadDeployedHash() throws SQLException {
         String hashColumn = "DEPLOYED_HASH";
-        String hashQuery =  "SELECT * FROM " + getFullyQualifiedScriptHistoryTable() + ";";
+        String hashQuery =  "SELECT * FROM " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + ";";
         log.debug("Loading hash with sql: {}", hashQuery);
         Statement statement = connection.createStatement();
         ResultSet resultSet = statement.executeQuery(hashQuery);
@@ -106,13 +106,13 @@ public class ScriptRepo {
     }
 
     public Long insertChangeSync(ChangeType changeType, Status status, String logMessage) throws SQLException {
-        String queryGetId = "SELECT count(1) FROM " + getFullyQualifiedChangeSyncTable() + ";";
+        String queryGetId = "SELECT count(1) FROM " + getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME) + ";";
         ResultSet rs = connection.createStatement().executeQuery(queryGetId);
         if(rs.next()) {
             changeSyncId =  rs.getLong(1) + 1;
         }
 
-        String insertSql = "INSERT INTO " + getFullyQualifiedChangeSyncTable() + " (ID, CHANGE_TYPE, STATUS, LOG, START_TIME) VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP);";
+        String insertSql = "INSERT INTO " + getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME) + " (ID, CHANGE_TYPE, STATUS, LOG, START_TIME) VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP);";
         PreparedStatement statement = connection.prepareStatement(insertSql);
         statement.setLong(1, changeSyncId);
         statement.setString(2, changeType.toString());
@@ -125,7 +125,7 @@ public class ScriptRepo {
     }
 
     public void updateChangeSync(ChangeType changeType, Status status, String logMessage, Long changeCount) throws SQLException {
-        String updateSql = "UPDATE " + getFullyQualifiedChangeSyncTable() + " SET CHANGE_TYPE=?, STATUS=?, LOG=?, CHANGE_COUNT=?, END_TIME=CURRENT_TIMESTAMP WHERE ID = ? ;";
+        String updateSql = "UPDATE " + getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME) + " SET CHANGE_TYPE=?, STATUS=?, LOG=?, CHANGE_COUNT=?, END_TIME=CURRENT_TIMESTAMP WHERE ID = ? ;";
         PreparedStatement statement = connection.prepareStatement(updateSql);
         statement.setString(1, changeType.toString());
         statement.setString(2, status.toString());
@@ -145,7 +145,7 @@ public class ScriptRepo {
         String deployedHash = Util.getMd5Hash(script.getContent());
         log.debug("Updating script hash of object {}", script.getId());
         if(scriptHash.containsKey(script.getId())) {
-            String updateSql = "UPDATE " + getFullyQualifiedScriptHistoryTable() + " SET ROLLBACK_SCRIPT=?, SCRIPT_HASH=?, DEPLOYED_HASH=?, CHANGE_SYNC_ID=?, updated_by=current_user, updated_ts=current_timestamp WHERE SCRIPT_ID=?;";
+            String updateSql = "UPDATE " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + " SET ROLLBACK_SCRIPT=?, SCRIPT_HASH=?, DEPLOYED_HASH=?, CHANGE_SYNC_ID=?, updated_by=current_user, updated_ts=current_timestamp WHERE SCRIPT_ID=?;";
             statement = connection.prepareStatement(updateSql);
             statement.setString(1, rollback);
             statement.setString(2, script.getHash());
@@ -155,7 +155,7 @@ public class ScriptRepo {
             log.debug("Updating script hash with the following SQL: {}", updateSql);
         }
         else {
-            String insertSql = "INSERT INTO " + getFullyQualifiedScriptHistoryTable() + " VALUES(?, ?, ?, ?, ?, ?, ?, current_user, current_timestamp, current_user, current_timestamp);";
+            String insertSql = "INSERT INTO " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + " VALUES(?, ?, ?, ?, ?, ?, ?, current_user, current_timestamp, current_user, current_timestamp);";
             statement = connection.prepareStatement(insertSql);
             statement.setString(1, script.getId());
             statement.setString(2, script.getFullObjectName());
@@ -173,7 +173,7 @@ public class ScriptRepo {
     private boolean insertScriptEvent(Script script, String status, String logs) throws SQLException {
         //varchar ID, varchar OBJECT_NAME, varchar SCRIPT_HASH, varchar STATUS, varchar log, varchar created_by, varchar created_ts;
         log.debug("Creating event for the object {} with status: {} and log: {} ", script.getObjectName(), status, logs);
-        String insertSql = "INSERT INTO " + getFullyQualifiedScriptEventTable() + " SELECT UUID_STRING(), ?, ?, ?, ?, ?, ?, current_user, current_timestamp;";
+        String insertSql = "INSERT INTO " + getFullyQualifiedTableName(SCRIPT_EVENT_TABLE_NAME) + " SELECT UUID_STRING(), ?, ?, ?, ?, ?, ?, current_user, current_timestamp;";
         PreparedStatement statement = connection.prepareStatement(insertSql);
         statement.setString(1, script.getId());
         statement.setObject(2, script.getFullObjectName());
@@ -306,30 +306,14 @@ public class ScriptRepo {
         return String.format("%s.%s.%s", getDatabaseName(), getSchemaName(), tableName);
     }
 
-    private String getFullyQualifiedChangeSyncTable() {
-        return getFullyQualifiedTableName(CHANGE_SYNC_TABLE_NAME);
-    }
-
-    private String getFullyQualifiedScriptHistoryTable() {
-        return getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME);
-    }
-
-    private String getFullyQualifiedScriptEventTable() {
-        return getFullyQualifiedTableName(SCRIPT_EVENT_TABLE_NAME);
-    }
-
-    private String getFullyQualifiedDependencyLineageTable() {
-        return getFullyQualifiedTableName(DEPENDENCY_LINEAGE_TABLE_NAME);
-    }
-
     public ResultSet executeQuery(String query) throws SQLException {
         return connection.createStatement().executeQuery(query);
     }
 
     public void insertDependencyList(List<ScriptDependency> dependencyList) throws SQLException {
-        String createTable = "CREATE TABLE IF NOT EXISTS " + getFullyQualifiedDependencyLineageTable() + "(OBJECT_NAME VARCHAR, OBJECT_TYPE VARCHAR, DEPENDENCY VARCHAR, DEPENDECY_OBEJECT_TYPE VARCHAR, CHANGE_SYNC_ID VARCHAR, CREATED_BY VARCHAR, CREATED_TS TIMESTAMP);";
+        String createTable = "CREATE TABLE IF NOT EXISTS " + getFullyQualifiedTableName(DEPENDENCY_LINEAGE_TABLE_NAME) + "(OBJECT_NAME VARCHAR, OBJECT_TYPE VARCHAR, DEPENDENCY VARCHAR, DEPENDECY_OBEJECT_TYPE VARCHAR, CHANGE_SYNC_ID VARCHAR, CREATED_BY VARCHAR, CREATED_TS TIMESTAMP);";
         connection.createStatement().executeUpdate(createTable);
-        StringBuilder insertSql = new StringBuilder("INSERT INTO " + getFullyQualifiedDependencyLineageTable() + " VALUES ");
+        StringBuilder insertSql = new StringBuilder("INSERT INTO " + getFullyQualifiedTableName(DEPENDENCY_LINEAGE_TABLE_NAME) + " VALUES ");
 
         for(ScriptDependency dependency: dependencyList) {
             String values = String.format("('%s', '%s', '%s', '%s', '%s', current_user, current_timestamp),", dependency.getObjectName(), dependency.getObjectType(), dependency.getDependency(), dependency.getDependencyObjectType(), changeSyncId);
@@ -366,7 +350,7 @@ public class ScriptRepo {
             return new ArrayList<>();
         }
         String allIdJoined = ids.stream().map(v -> "'" + v + "'").collect(Collectors.joining(",", "(", ");"));
-        String query = "SELECT * FROM " + getFullyQualifiedScriptHistoryTable() + " where SCRIPT_ID in " + allIdJoined;
+        String query = "SELECT * FROM " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + " where SCRIPT_ID in " + allIdJoined;
         PreparedStatement statement = connection.prepareStatement(query);
         ResultSet rs = statement.executeQuery();
         List<MigrationScript> migrations = new ArrayList<>();
@@ -444,7 +428,7 @@ public class ScriptRepo {
     }
 
     private void deleteScriptHash(MigrationScript migration) throws SQLException {
-        String deleteSql = "DELETE FROM " + getFullyQualifiedScriptHistoryTable() + " WHERE SCRIPT_ID=?;";
+        String deleteSql = "DELETE FROM " + getFullyQualifiedTableName(SCRIPT_HISTORY_TABLE_NAME) + " WHERE SCRIPT_ID=?;";
         PreparedStatement statement = connection.prepareStatement(deleteSql);
         statement.setString(1, migration.getId());
         statement.executeUpdate();


### PR DESCRIPTION
## Problem

When DLSync manages account-level objects (databases or schemas), it breaks with errors like:
- `Table 'DL_SYNC_SCRIPT_HISTORY' does not exist or not authorized`
- Similar errors for `DL_SYNC_SCRIPT_EVENT` and `DL_SYNC_CHANGE_SYNC` tables

### Root Cause
When Snowflake executes `CREATE DATABASE` or `CREATE SCHEMA` commands, it automatically changes the session context to the newly created database/schema. Since DLSync uses non-fully-qualified table names for its metadata tables, subsequent queries fail because they look for the tables in the new context instead of the original DLSync schema.

## Solution

This PR updates all references to DLSync metadata tables to use fully qualified names in the format `database.schema.table_name`.

### Changes Made

1. **Added helper methods** to generate fully qualified table names:
   - `getFullyQualifiedTableName(String tableName)`
   - `getFullyQualifiedChangeSyncTable()`
   - `getFullyQualifiedScriptHistoryTable()`
   - `getFullyQualifiedScriptEventTable()`
   - `getFullyQualifiedDependencyLineageTable()`

2. **Updated all SQL queries** in `ScriptRepo.java` to use these helper methods, ensuring all references to metadata tables are fully qualified regardless of the current session context.

### Testing

Tested with a custom Docker image deploying account-level objects (databases and schemas). The fix successfully prevents the session context issue and DLSync operations complete without errors.

## Impact

This fix ensures DLSync can manage account-level objects without breaking, making it fully compatible with all object types it claims to support.

Fixes the issue reported in the repository discussions.

References #56 